### PR TITLE
Adding setup/teardown for Ethernet on sim target on Ubuntu

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,10 +2,5 @@ __pycache__
 *.pyc
 *.egg-info
 *.vcd
-*.o
-*.bin
-*.elf
-*.a
-test/csr.csv
 outgoing
 build

--- a/Makefile
+++ b/Makefile
@@ -38,9 +38,10 @@ firmware:
 	cd firmware && make clean all
 
 load-firmware:
-	litex_term --kernel firmware/firmware.bin COM8
+	cd firmware && make load
 
 clean:
 	rm -rf build
+	cd firmware && make clean
 
 .PHONY: load firmware load-firmware

--- a/Makefile
+++ b/Makefile
@@ -2,46 +2,29 @@ CPU ?= lm32
 export CLANG=0
 
 opsis_base:
-	rm -rf build
-	./opsis_base.py --nocompile-gateware --cpu-type $(CPU)
-	cd firmware && make clean all
+	rm -rf build/opsis_base
 	./opsis_base.py --cpu-type $(CPU)
 
 opsis_minisoc:
-	rm -rf build
-	./opsis_base.py --with-ethernet --nocompile-gateware --cpu-type $(CPU)
-	cd firmware && make clean all
+	rm -rf build/opsis_minisoc
 	./opsis_base.py --with-ethernet --cpu-type $(CPU)
 
 opsis_video:
-	rm -rf build
-	./opsis_video.py --nocompile-gateware --cpu-type $(CPU)
-	cd firmware && make clean all
+	rm -rf build/opsis_video
 	./opsis_video.py --cpu-type $(CPU)
 
 opsis_hdmi2usb:
-	rm -rf build
-	./opsis_hdmi2usb.py --nocompile-gateware --cpu-type $(CPU)
-	cd firmware && make clean all
+	rm -rf build/opsis_hdmi2usb
 	./opsis_hdmi2usb.py --cpu-type $(CPU)
 
 opsis_sim:
-	rm -rf build
-	./opsis_sim.py --nocompile-gateware --with-ethernet --cpu-type $(CPU)
-	cd firmware && make clean all
+	rm -rf build/opsis_sim
 	./opsis_sim.py --with-ethernet --cpu-type $(CPU)
 
 load:
 	./load.py
 
-firmware:
-	cd firmware && make clean all
-
-load-firmware:
-	cd firmware && make load
-
 clean:
 	rm -rf build
-	cd firmware && make clean
 
 .PHONY: load firmware load-firmware

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,19 @@ opsis_hdmi2usb:
 	rm -rf build/opsis_hdmi2usb
 	./opsis_hdmi2usb.py --cpu-type $(CPU)
 
+opsis_sim_setup:
+	sudo openvpn --mktun --dev tap0
+	sudo ifconfig tap0 192.168.1.100 up
+	sudo mknod /dev/net/tap0 c 10 200
+	sudo chown $(shell whoami) /dev/net/tap0
+	sudo atftpd --bind-address 192.168.1.100 --daemon --logfile /dev/stdout --no-fork --user $(shell whoami) build/opsis_sim/software/ &
+
+opsis_sim_teardown:
+	sudo killall atftpd || true	# FIXME: This is dangerous...
+	sudo rm -f /dev/net/tap0
+	sudo ifconfig tap0 down
+	sudo openvpn --rmtun --dev tap0
+
 opsis_sim:
 	rm -rf build/opsis_sim
 	./opsis_sim.py --with-ethernet --cpu-type $(CPU)

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -35,7 +35,7 @@ all: firmware.bin
 %.bin: %.elf
 	$(OBJCOPY) -O binary $< $@
 	chmod -x $@
-	cp $@ $(BUILD_DIRECTORY)/boot.bin
+	cp $@ $(BUILD_DIRECTORY)/software/boot.bin
 
 firmware.elf: $(OBJECTS) libs
 	$(LD) $(LDFLAGS) \

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -1,10 +1,7 @@
-OPSIS_DIR=../build
-
-include $(OPSIS_DIR)/software/include/generated/variables.mak
+include ../include/generated/variables.mak
 include $(SOC_DIRECTORY)/software/common.mak
 
-UIPDIR=uip
-LIBUIPDIR=libuip
+BUILD_DIRECTORY=$(BUILDINC_DIRECTORY)/../../
 
 OBJECTS=isr.o \
 		ethernet.o \
@@ -25,7 +22,10 @@ OBJECTS=isr.o \
                 i2c.o \
 		main.o
 
-CFLAGS += -I. -I$(UIPDIR) -I$(LIBUIPDIR)
+CFLAGS += \
+	-I. \
+	-I$(LIBUIP_DIRECTORY)/../uip \
+	-I$(LIBUIP_DIRECTORY)
 
 all: firmware.bin
 
@@ -35,37 +35,34 @@ all: firmware.bin
 %.bin: %.elf
 	$(OBJCOPY) -O binary $< $@
 	chmod -x $@
-	cp $@ boot.bin
+	cp $@ $(BUILD_DIRECTORY)/boot.bin
 
 firmware.elf: $(OBJECTS) libs
 	$(LD) $(LDFLAGS) \
-		-T linker.ld \
+		-T $(FIRMWARE_DIRECTORY)/linker.ld \
 		-N -o $@ \
-		 $(OPSIS_DIR)/software/libbase/crt0-$(CPU).o \
-		$(OBJECTS) \
-		-L$(OPSIS_DIR)/software/libbase \
-		-L$(OPSIS_DIR)/software/libcompiler_rt \
-		-L$(LIBUIPDIR) \
+                ../libbase/crt0-$(CPU).o \
+                $(OBJECTS) \
+                -L../libnet \
+                -L../libbase \
+                -L../libcompiler_rt \
+		-L../libuip \
 		-lbase-nofloat -luip -lcompiler_rt
 	chmod -x $@
 
-main.o: main.c
+main.o: $(FIRMWARE_DIRECTORY)/main.c
 	$(compile)
 
-%.o: %.c
+%.o: $(FIRMWARE_DIRECTORY)/%.c
 	$(compile)
 
-%.o: %.S
+%.o: $(FIRMWARE_DIRECTORY)/%.S
 	$(assemble)
-
-libs:
-	$(MAKE) -C $(LIBUIPDIR)
 
 load: firmware.bin
 	litex_term --kernel firmware.bin COM8
 
 clean:
-	cd libuip && make clean
 	$(RM) $(OBJECTS) $(OBJECTS:.o=.d) firmware.elf firmware.bin .*~ *~
 
 .PHONY: all main.o clean libs load

--- a/firmware/libuip/Makefile
+++ b/firmware/libuip/Makefile
@@ -1,16 +1,15 @@
-OPSIS_DIR=../../build
-
-include $(OPSIS_DIR)/software/include/generated/variables.mak
+include ../include/generated/variables.mak
 include $(SOC_DIRECTORY)/software/common.mak
 
-UIPDIR=../uip
-LIBUIPDIR=../libuip
+VPATH=$(LIBUIP_DIRECTORY)
 
-CFLAGS += $(CPPFLAGS) -I. \
-	-I$(UIPDIR) \
-	-I$(UIPDIR)/net \
-	-I$(UIPDIR)/net\ip \
-	-I$(UIPDIR)/net\ipv4 \
+UIPDIR=../uip
+LIBUIPDIR=.
+
+CFLAGS += $(CPPFLAGS) \
+	-I$(LIBUIP_DIRECTORY)/$(LIBUIPDIR) \
+	-I$(LIBUIP_DIRECTORY)/$(UIPDIR) \
+	-I$(LIBUIP_DIRECTORY)/$(UIPDIR)/net \
 	-Wno-char-subscripts \
 	-fno-strict-aliasing -fpack-struct
 
@@ -50,9 +49,10 @@ UIPCOREOBJS=$(UIPDIR)/net/ip/dhcpc.o \
 	$(UIPDIR)/sys/timer.o \
 	$(UIPDIR)/lib/list.o
 
-UIPARCHOBJS=clock-arch.o \
-	rtimer-arch.o \
-	liteethmac-drv.o
+UIPARCHOBJS=\
+	$(LIBUIPDIR)/clock-arch.o \
+	$(LIBUIPDIR)/rtimer-arch.o \
+	$(LIBUIPDIR)/liteethmac-drv.o
 
 UIPOBJS=$(UIPCOREOBJS) $(UIPARCHOBJS)
 OBJS_LIB+=$(UIPOBJS)
@@ -64,9 +64,11 @@ all: $(UIPLIB)
 .PHONY: all compile clean
 
 %.o: %.c
+	@mkdir -p $(@D)
 	$(compile)
 
 %.o: %.S
+	@mkdir -p $(@D)
 	$(assemble)
 
 clean:

--- a/opsis_base.py
+++ b/opsis_base.py
@@ -271,10 +271,13 @@ def main():
 
     platform = opsis_platform.Platform()
     cls = MiniSoC if args.with_ethernet else BaseSoC
+    builddir = "opsis_base/" if not args.with_ethernet else "opsis_base/"
     soc = cls(platform, **soc_sdram_argdict(args))
-    builder = Builder(soc, output_dir="build",
+    builder = Builder(soc, output_dir="build/{}".format(builddir),
                       compile_gateware=not args.nocompile_gateware,
-                      csr_csv="test/csr.csv")
+                      csr_csv="build/{}/test/csr.csv".format(builddir))
+    builder.add_software_package("libuip", "{}/firmware/libuip".format(os.getcwd()))
+    builder.add_software_package("firmware", "{}/firmware".format(os.getcwd()))
     vns = builder.build()
 
 if __name__ == "__main__":

--- a/opsis_base.py
+++ b/opsis_base.py
@@ -278,6 +278,7 @@ def main():
                       csr_csv="build/{}/test/csr.csv".format(builddir))
     builder.add_software_package("libuip", "{}/firmware/libuip".format(os.getcwd()))
     builder.add_software_package("firmware", "{}/firmware".format(os.getcwd()))
+    os.makedirs("build/{}/test".format(builddir)) # FIXME: Remove when builder does this.
     vns = builder.build()
 
 if __name__ == "__main__":

--- a/opsis_hdmi2usb.py
+++ b/opsis_hdmi2usb.py
@@ -54,6 +54,7 @@ def main():
                       csr_csv="build/opsis_hdmi2usb/test/csr.csv")
     builder.add_software_package("libuip", "{}/firmware/libuip".format(os.getcwd()))
     builder.add_software_package("firmware", "{}/firmware".format(os.getcwd()))
+    os.makedirs("build/opsis_hdmi2usb/test") # FIXME: Remove when builder does this.
     vns = builder.build()
 
 if __name__ == "__main__":

--- a/opsis_hdmi2usb.py
+++ b/opsis_hdmi2usb.py
@@ -49,9 +49,11 @@ def main():
 
     platform = opsis_platform.Platform()
     soc = HDMI2USBSoC(platform, **soc_sdram_argdict(args))
-    builder = Builder(soc, output_dir="build",
+    builder = Builder(soc, output_dir="build/opsis_hdmi2usb/",
                       compile_gateware=not args.nocompile_gateware,
-                      csr_csv="test/csr.csv")
+                      csr_csv="build/opsis_hdmi2usb/test/csr.csv")
+    builder.add_software_package("libuip", "{}/firmware/libuip".format(os.getcwd()))
+    builder.add_software_package("firmware", "{}/firmware".format(os.getcwd()))
     vns = builder.build()
 
 if __name__ == "__main__":

--- a/opsis_sim.py
+++ b/opsis_sim.py
@@ -2,6 +2,7 @@
 
 import argparse
 import importlib
+import os
 
 from litex.gen import *
 from litex.gen.genlib.io import CRG

--- a/opsis_sim.py
+++ b/opsis_sim.py
@@ -144,9 +144,11 @@ def main():
 
     cls = MiniSoC if args.with_ethernet else BaseSoC
     soc = cls(**soc_sdram_argdict(args))
-    builder = Builder(soc, output_dir="build",
+    builder = Builder(soc, output_dir="build/opsis_sim/",
                       compile_gateware=not args.nocompile_gateware,
-                      csr_csv="test/csr.csv")
+                      csr_csv="build/opsis_sim/test/csr.csv")
+    builder.add_software_package("libuip", "{}/firmware/libuip".format(os.getcwd()))
+    builder.add_software_package("firmware", "{}/firmware".format(os.getcwd()))
     builder.build()
 
 

--- a/opsis_sim.py
+++ b/opsis_sim.py
@@ -149,6 +149,7 @@ def main():
                       csr_csv="build/opsis_sim/test/csr.csv")
     builder.add_software_package("libuip", "{}/firmware/libuip".format(os.getcwd()))
     builder.add_software_package("firmware", "{}/firmware".format(os.getcwd()))
+    os.makedirs("build/opsis_sim/test") # FIXME: Remove when builder does this.
     builder.build()
 
 

--- a/opsis_video.py
+++ b/opsis_video.py
@@ -78,9 +78,11 @@ def main():
 
     platform = opsis_platform.Platform()
     soc = VideoMixerSoC(platform, **soc_sdram_argdict(args))
-    builder = Builder(soc, output_dir="build",
+    builder = Builder(soc, output_dir="build/opsis_video/",
                       compile_gateware=not args.nocompile_gateware,
-                      csr_csv="test/csr.csv")
+                      csr_csv="build/opsis_video/test/csr.csv")
+    builder.add_software_package("libuip", "{}/firmware/libuip".format(os.getcwd()))
+    builder.add_software_package("firmware", "{}/firmware".format(os.getcwd()))
     vns = builder.build()
 
 if __name__ == "__main__":

--- a/opsis_video.py
+++ b/opsis_video.py
@@ -83,6 +83,7 @@ def main():
                       csr_csv="build/opsis_video/test/csr.csv")
     builder.add_software_package("libuip", "{}/firmware/libuip".format(os.getcwd()))
     builder.add_software_package("firmware", "{}/firmware".format(os.getcwd()))
+    os.makedirs("build/opsis_video/test") # FIXME: Remove when builder does this.
     vns = builder.build()
 
 if __name__ == "__main__":


### PR DESCRIPTION
Makes it easier for using the sim target on Linux / Ubuntu.

 * Merge https://github.com/enjoy-digital/opsis-soc/pull/20 first.