### PR TITLE
Allow simultaneous usage of the different UARTs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,10 +2,5 @@ __pycache__
 *.pyc
 *.egg-info
 *.vcd
-*.o
-*.bin
-*.elf
-*.a
-test/csr.csv
 outgoing
 build

--- a/Makefile
+++ b/Makefile
@@ -38,9 +38,10 @@ firmware:
 	cd firmware && make clean all
 
 load-firmware:
-	litex_term --kernel firmware/firmware.bin COM8
+	cd firmware && make load
 
 clean:
 	rm -rf build
+	cd firmware && make clean
 
 .PHONY: load firmware load-firmware

--- a/Makefile
+++ b/Makefile
@@ -2,46 +2,29 @@ CPU ?= lm32
 export CLANG=0
 
 opsis_base:
-	rm -rf build
-	./opsis_base.py --nocompile-gateware --cpu-type $(CPU)
-	cd firmware && make clean all
+	rm -rf build/opsis_base
 	./opsis_base.py --cpu-type $(CPU)
 
 opsis_minisoc:
-	rm -rf build
-	./opsis_base.py --with-ethernet --nocompile-gateware --cpu-type $(CPU)
-	cd firmware && make clean all
+	rm -rf build/opsis_minisoc
 	./opsis_base.py --with-ethernet --cpu-type $(CPU)
 
 opsis_video:
-	rm -rf build
-	./opsis_video.py --nocompile-gateware --cpu-type $(CPU)
-	cd firmware && make clean all
+	rm -rf build/opsis_video
 	./opsis_video.py --cpu-type $(CPU)
 
 opsis_hdmi2usb:
-	rm -rf build
-	./opsis_hdmi2usb.py --nocompile-gateware --cpu-type $(CPU)
-	cd firmware && make clean all
+	rm -rf build/opsis_hdmi2usb
 	./opsis_hdmi2usb.py --cpu-type $(CPU)
 
 opsis_sim:
-	rm -rf build
-	./opsis_sim.py --nocompile-gateware --with-ethernet --cpu-type $(CPU)
-	cd firmware && make clean all
+	rm -rf build/opsis_sim
 	./opsis_sim.py --with-ethernet --cpu-type $(CPU)
 
 load:
 	./load.py
 
-firmware:
-	cd firmware && make clean all
-
-load-firmware:
-	cd firmware && make load
-
 clean:
 	rm -rf build
-	cd firmware && make clean
 
 .PHONY: load firmware load-firmware

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -35,7 +35,7 @@ all: firmware.bin
 %.bin: %.elf
 	$(OBJCOPY) -O binary $< $@
 	chmod -x $@
-	cp $@ $(BUILD_DIRECTORY)/boot.bin
+	cp $@ $(BUILD_DIRECTORY)/software/boot.bin
 
 firmware.elf: $(OBJECTS) libs
 	$(LD) $(LDFLAGS) \

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -1,10 +1,7 @@
-OPSIS_DIR=../build
-
-include $(OPSIS_DIR)/software/include/generated/variables.mak
+include ../include/generated/variables.mak
 include $(SOC_DIRECTORY)/software/common.mak
 
-UIPDIR=uip
-LIBUIPDIR=libuip
+BUILD_DIRECTORY=$(BUILDINC_DIRECTORY)/../../
 
 OBJECTS=isr.o \
 		ethernet.o \
@@ -25,7 +22,10 @@ OBJECTS=isr.o \
                 i2c.o \
 		main.o
 
-CFLAGS += -I. -I$(UIPDIR) -I$(LIBUIPDIR)
+CFLAGS += \
+	-I. \
+	-I$(LIBUIP_DIRECTORY)/../uip \
+	-I$(LIBUIP_DIRECTORY)
 
 all: firmware.bin
 
@@ -35,37 +35,34 @@ all: firmware.bin
 %.bin: %.elf
 	$(OBJCOPY) -O binary $< $@
 	chmod -x $@
-	cp $@ boot.bin
+	cp $@ $(BUILD_DIRECTORY)/boot.bin
 
 firmware.elf: $(OBJECTS) libs
 	$(LD) $(LDFLAGS) \
-		-T linker.ld \
+		-T $(FIRMWARE_DIRECTORY)/linker.ld \
 		-N -o $@ \
-		 $(OPSIS_DIR)/software/libbase/crt0-$(CPU).o \
-		$(OBJECTS) \
-		-L$(OPSIS_DIR)/software/libbase \
-		-L$(OPSIS_DIR)/software/libcompiler_rt \
-		-L$(LIBUIPDIR) \
+                ../libbase/crt0-$(CPU).o \
+                $(OBJECTS) \
+                -L../libnet \
+                -L../libbase \
+                -L../libcompiler_rt \
+		-L../libuip \
 		-lbase-nofloat -luip -lcompiler_rt
 	chmod -x $@
 
-main.o: main.c
+main.o: $(FIRMWARE_DIRECTORY)/main.c
 	$(compile)
 
-%.o: %.c
+%.o: $(FIRMWARE_DIRECTORY)/%.c
 	$(compile)
 
-%.o: %.S
+%.o: $(FIRMWARE_DIRECTORY)/%.S
 	$(assemble)
-
-libs:
-	$(MAKE) -C $(LIBUIPDIR)
 
 load: firmware.bin
 	litex_term --kernel firmware.bin COM8
 
 clean:
-	cd libuip && make clean
 	$(RM) $(OBJECTS) $(OBJECTS:.o=.d) firmware.elf firmware.bin .*~ *~
 
 .PHONY: all main.o clean libs load

--- a/firmware/libuip/Makefile
+++ b/firmware/libuip/Makefile
@@ -1,16 +1,15 @@
-OPSIS_DIR=../../build
-
-include $(OPSIS_DIR)/software/include/generated/variables.mak
+include ../include/generated/variables.mak
 include $(SOC_DIRECTORY)/software/common.mak
 
-UIPDIR=../uip
-LIBUIPDIR=../libuip
+VPATH=$(LIBUIP_DIRECTORY)
 
-CFLAGS += $(CPPFLAGS) -I. \
-	-I$(UIPDIR) \
-	-I$(UIPDIR)/net \
-	-I$(UIPDIR)/net\ip \
-	-I$(UIPDIR)/net\ipv4 \
+UIPDIR=../uip
+LIBUIPDIR=.
+
+CFLAGS += $(CPPFLAGS) \
+	-I$(LIBUIP_DIRECTORY)/$(LIBUIPDIR) \
+	-I$(LIBUIP_DIRECTORY)/$(UIPDIR) \
+	-I$(LIBUIP_DIRECTORY)/$(UIPDIR)/net \
 	-Wno-char-subscripts \
 	-fno-strict-aliasing -fpack-struct
 
@@ -50,9 +49,10 @@ UIPCOREOBJS=$(UIPDIR)/net/ip/dhcpc.o \
 	$(UIPDIR)/sys/timer.o \
 	$(UIPDIR)/lib/list.o
 
-UIPARCHOBJS=clock-arch.o \
-	rtimer-arch.o \
-	liteethmac-drv.o
+UIPARCHOBJS=\
+	$(LIBUIPDIR)/clock-arch.o \
+	$(LIBUIPDIR)/rtimer-arch.o \
+	$(LIBUIPDIR)/liteethmac-drv.o
 
 UIPOBJS=$(UIPCOREOBJS) $(UIPARCHOBJS)
 OBJS_LIB+=$(UIPOBJS)
@@ -64,9 +64,11 @@ all: $(UIPLIB)
 .PHONY: all compile clean
 
 %.o: %.c
+	@mkdir -p $(@D)
 	$(compile)
 
 %.o: %.S
+	@mkdir -p $(@D)
 	$(assemble)
 
 clean:

--- a/gateware/shared_uart.py
+++ b/gateware/shared_uart.py
@@ -21,7 +21,6 @@ class SharedUART(Module):
         self.submodules.phy = uart.RS232PHY(self, clk_freq, baud_rate)
         self.submodules.uart = uart.UART(self.phy)
 
-
     def add_uart_pads(self, new_pads):
         self.tx_signals.append(new_pads.tx)
         self.rx_signals.append(new_pads.rx)

--- a/gateware/shared_uart.py
+++ b/gateware/shared_uart.py
@@ -1,0 +1,42 @@
+
+"""
+UART which is connected to multiple sets of pins.
+"""
+
+import operator
+
+from litex.gen import *
+
+from litex.soc.cores import uart
+
+
+class SharedUART(Module):
+
+    def __init__(self, clk_freq, baud_rate):
+        self.tx = Signal()
+        self.rx = Signal()
+        self.tx_signals = []
+        self.rx_signals = []
+
+        self.submodules.phy = uart.RS232PHY(self, clk_freq, baud_rate)
+        self.submodules.uart = uart.UART(self.phy)
+
+
+    def add_uart_pads(self, new_pads):
+        self.tx_signals.append(new_pads.tx)
+        self.rx_signals.append(new_pads.rx)
+
+    def do_finalize(self):
+        for tx_sig in self.tx_signals:
+            self.comb += [
+                # TX
+                tx_sig.eq(self.tx),
+            ]
+
+        self.comb += [
+            # RX
+            self.rx.eq(reduce(operator.__and__, self.rx_signals))
+        ]
+
+
+# FIXME: Add a test for the shared UART

--- a/opsis_base.py
+++ b/opsis_base.py
@@ -271,7 +271,7 @@ def main():
 
     platform = opsis_platform.Platform()
     cls = MiniSoC if args.with_ethernet else BaseSoC
-    builddir = "opsis_base/" if not args.with_ethernet else "opsis_base/"
+    builddir = "opsis_base/" if not args.with_ethernet else "opsis_minisoc/"
     soc = cls(platform, **soc_sdram_argdict(args))
     builder = Builder(soc, output_dir="build/{}".format(builddir),
                       compile_gateware=not args.nocompile_gateware,

--- a/opsis_base.py
+++ b/opsis_base.py
@@ -271,10 +271,13 @@ def main():
 
     platform = opsis_platform.Platform()
     cls = MiniSoC if args.with_ethernet else BaseSoC
+    builddir = "opsis_base/" if not args.with_ethernet else "opsis_base/"
     soc = cls(platform, **soc_sdram_argdict(args))
-    builder = Builder(soc, output_dir="build",
+    builder = Builder(soc, output_dir="build/{}".format(builddir),
                       compile_gateware=not args.nocompile_gateware,
-                      csr_csv="test/csr.csv")
+                      csr_csv="build/{}/test/csr.csv".format(builddir))
+    builder.add_software_package("libuip", "{}/firmware/libuip".format(os.getcwd()))
+    builder.add_software_package("firmware", "{}/firmware".format(os.getcwd()))
     vns = builder.build()
 
 if __name__ == "__main__":

--- a/opsis_base.py
+++ b/opsis_base.py
@@ -278,6 +278,7 @@ def main():
                       csr_csv="build/{}/test/csr.csv".format(builddir))
     builder.add_software_package("libuip", "{}/firmware/libuip".format(os.getcwd()))
     builder.add_software_package("firmware", "{}/firmware".format(os.getcwd()))
+    os.makedirs("build/{}/test".format(builddir)) # FIXME: Remove when builder does this.
     vns = builder.build()
 
 if __name__ == "__main__":

--- a/opsis_base.py
+++ b/opsis_base.py
@@ -32,6 +32,7 @@ import opsis_platform
 
 from gateware import dna
 from gateware import firmware
+from gateware import shared_uart
 
 
 def csr_map_update(csr_map, csr_peripherals):
@@ -179,9 +180,16 @@ class BaseSoC(SoCSDRAM):
         SoCSDRAM.__init__(self, platform, clk_freq,
             integrated_rom_size=0x8000,
             integrated_sram_size=0x8000,
+            with_uart=False,
             **kwargs)
         self.submodules.crg = _CRG(platform, clk_freq)
         self.submodules.dna = dna.DNA()
+
+        self.submodules.suart = shared_uart.SharedUART(self.clk_freq, 115200)
+        self.suart.add_uart_pads(platform.request('fx2_serial'))
+        self.suart.add_uart_pads(platform.request('tofe_lsio_serial'))
+        self.suart.add_uart_pads(platform.request('tofe_lsio_pmod_serial'))
+        self.submodules.uart = self.suart.uart
 
         self.submodules.spiflash = spi_flash.SpiFlash(
             platform.request("spiflash4x"), dummy=platform.spiflash_read_dummy_bits, div=platform.spiflash_clock_div)

--- a/opsis_hdmi2usb.py
+++ b/opsis_hdmi2usb.py
@@ -54,6 +54,7 @@ def main():
                       csr_csv="build/opsis_hdmi2usb/test/csr.csv")
     builder.add_software_package("libuip", "{}/firmware/libuip".format(os.getcwd()))
     builder.add_software_package("firmware", "{}/firmware".format(os.getcwd()))
+    os.makedirs("build/opsis_hdmi2usb/test") # FIXME: Remove when builder does this.
     vns = builder.build()
 
 if __name__ == "__main__":

--- a/opsis_hdmi2usb.py
+++ b/opsis_hdmi2usb.py
@@ -49,9 +49,11 @@ def main():
 
     platform = opsis_platform.Platform()
     soc = HDMI2USBSoC(platform, **soc_sdram_argdict(args))
-    builder = Builder(soc, output_dir="build",
+    builder = Builder(soc, output_dir="build/opsis_hdmi2usb/",
                       compile_gateware=not args.nocompile_gateware,
-                      csr_csv="test/csr.csv")
+                      csr_csv="build/opsis_hdmi2usb/test/csr.csv")
+    builder.add_software_package("libuip", "{}/firmware/libuip".format(os.getcwd()))
+    builder.add_software_package("firmware", "{}/firmware".format(os.getcwd()))
     vns = builder.build()
 
 if __name__ == "__main__":

--- a/opsis_platform.py
+++ b/opsis_platform.py
@@ -182,6 +182,8 @@ _io = [
         Subsignal("sda", Pins("AB17"), IOStandard("I2C")),
         Subsignal("hpd_notif", Pins("AB18"), IOStandard("LVCMOS33"))
     ),
+
+    # FX2 USB Interface
     ("fx2", 0,
         Subsignal("ifclk", Pins("P20"), IOStandard("LVCMOS33")),
         Subsignal("data", Pins("C20 C22 L15 K16 D21 D22 G19 F20 H18 H19 F21 F22 E20 E22 J19 H20"), IOStandard("LVCMOS33")),
@@ -196,26 +198,42 @@ _io = [
         Subsignal("pktend_n", Pins("J16"), IOStandard("LVCMOS33"),  Misc("DRIVE=12"))
     ),
 
+    # To Cypress FX2 UART0
+    # WARNING: This was labelled incorrectly - https://github.com/timvideos/HDMI2USB-numato-opsis-hardware/issues/13
+    # Can be accessed via `opsis-mode-switch --mode=serial`
+    # FIXME: Will be supported by `opsis-mode-switch --mode=jtag` longer term.
+    ("fx2_serial", 0,
+        # CY_RXD1 - P18 - Cypress RXD0
+        Subsignal("tx", Pins("P18"), IOStandard("LVCMOS33")),
+        # CY_TXD1 - T17 - Cypress TXD0
+        Subsignal("rx", Pins("T17"), IOStandard("LVCMOS33"), Misc("PULLUP")),
+    ),
+    # To Cypress FX2 UART1
+    #("serial", 1,
+    #    Subsignal("rx", Pins("A16"), IOStandard("LVCMOS33")),
+    #    Subsignal("tx", Pins("B16"), IOStandard("LVCMOS33")),
+    #),
+    #
+
     # FIXME: This assumes a TOFE LowSpeedIO board is currently connected.
     # -----------------------------------
 
     # serial
-    ("serial_debug", 0,
+    ("tofe_lsio_serial", 0,
         Subsignal("tx", Pins(tofe_pin(tofe_low_speed_io("rx")))),
         Subsignal("rx", Pins(tofe_pin(tofe_low_speed_io("tx")))),
         IOStandard("LVCMOS33")
     ),
 
     # user leds
-    ("user_led", 0, Pins(tofe_pin(tofe_low_speed_io("led1"))), IOStandard("LVCMOS33")),
-    ("user_led", 1, Pins(tofe_pin(tofe_low_speed_io("led2"))), IOStandard("LVCMOS33")),
-    ("user_led", 2, Pins(tofe_pin(tofe_low_speed_io("led3"))), IOStandard("LVCMOS33")),
-    ("user_led", 3, Pins(tofe_pin(tofe_low_speed_io("led4"))), IOStandard("LVCMOS33")),
+    ("tofe_lsio_user_led", 0, Pins(tofe_pin(tofe_low_speed_io("led1"))), IOStandard("LVCMOS33"), Misc("DRIVE=12")),
+    ("tofe_lsio_user_led", 1, Pins(tofe_pin(tofe_low_speed_io("led2"))), IOStandard("LVCMOS33"), Misc("DRIVE=12")),
+    ("tofe_lsio_user_led", 2, Pins(tofe_pin(tofe_low_speed_io("led3"))), IOStandard("LVCMOS33"), Misc("DRIVE=12")),
+    ("tofe_lsio_user_led", 3, Pins(tofe_pin(tofe_low_speed_io("led4"))), IOStandard("LVCMOS33"), Misc("DRIVE=12")),
 
-    # serial
-    ("serial", 0,
-        # PmodUSBUART
-        # Pmod Type4 - UART
+    # PmodUSBUART or similar device connected to the "p3" Pmod connector.
+    ("tofe_lsio_pmod_serial", 0,
+        # PmodUSBUART - Pmod Type4 - UART
         # Pin 1 - CTS - In  - Peripheral can transmit
         # Pin 2 - TXD - Out - Data - Host to peripheral
         # Pin 3 - RXD - In  - Data - Peripheral to host

--- a/opsis_platform.py
+++ b/opsis_platform.py
@@ -48,6 +48,8 @@ _tofe_io = {
     "diff_io_a6p" : "B2",
     "diff_io_b4n" : "D5",
     "diff_io_b4p" : "D4",
+    "smclk"       : "N6",
+    "smdat"       : "N7",
     "pcie_reset"  : "D3"
 }
 
@@ -217,11 +219,16 @@ _io = [
 
     # FIXME: This assumes a TOFE LowSpeedIO board is currently connected.
     # -----------------------------------
+    ("tofe", 0,
+        Subsignal("rst", Pins(tofe_pin("pcie_reset")), IOStandard("I2C"), Misc("PULLUP")),
+        Subsignal("scl", Pins(tofe_pin("smclk")), IOStandard("I2C")),
+        Subsignal("sda", Pins(tofe_pin("smdat")), IOStandard("I2C")),
+    ),
 
     # serial
     ("tofe_lsio_serial", 0,
-        Subsignal("tx", Pins(tofe_pin(tofe_low_speed_io("tx")))),
-        Subsignal("rx", Pins(tofe_pin(tofe_low_speed_io("rx"))), Misc("PULLUP")),
+        Subsignal("tx", Pins(tofe_pin(tofe_low_speed_io("rx")))),
+        Subsignal("rx", Pins(tofe_pin(tofe_low_speed_io("tx"))), Misc("PULLUP")),
         IOStandard("LVCMOS33")
     ),
 
@@ -230,6 +237,12 @@ _io = [
     ("tofe_lsio_user_led", 1, Pins(tofe_pin(tofe_low_speed_io("led2"))), IOStandard("LVCMOS33"), Misc("DRIVE=12")),
     ("tofe_lsio_user_led", 2, Pins(tofe_pin(tofe_low_speed_io("led3"))), IOStandard("LVCMOS33"), Misc("DRIVE=12")),
     ("tofe_lsio_user_led", 3, Pins(tofe_pin(tofe_low_speed_io("led4"))), IOStandard("LVCMOS33"), Misc("DRIVE=12")),
+
+    # push buttons
+    ("tofe_lsio_user_sw", 0, Pins(tofe_pin(tofe_low_speed_io("sw1"))), IOStandard("LVCMOS33"), Misc("PULLUP")),
+    ("tofe_lsio_user_sw", 1, Pins(tofe_pin(tofe_low_speed_io("sw2"))), IOStandard("LVCMOS33"), Misc("PULLUP")),
+    ("tofe_lsio_user_sw", 2, Pins(tofe_pin(tofe_low_speed_io("sw3"))), IOStandard("LVCMOS33"), Misc("PULLUP")),
+    ("tofe_lsio_user_sw", 3, Pins(tofe_pin(tofe_low_speed_io("sw4"))), IOStandard("LVCMOS33"), Misc("PULLUP")),
 
     # PmodUSBUART or similar device connected to the "p3" Pmod connector.
     ("tofe_lsio_pmod_serial", 0,

--- a/opsis_platform.py
+++ b/opsis_platform.py
@@ -220,8 +220,8 @@ _io = [
 
     # serial
     ("tofe_lsio_serial", 0,
-        Subsignal("tx", Pins(tofe_pin(tofe_low_speed_io("rx")))),
-        Subsignal("rx", Pins(tofe_pin(tofe_low_speed_io("tx")))),
+        Subsignal("tx", Pins(tofe_pin(tofe_low_speed_io("tx")))),
+        Subsignal("rx", Pins(tofe_pin(tofe_low_speed_io("rx"))), Misc("PULLUP")),
         IOStandard("LVCMOS33")
     ),
 
@@ -241,7 +241,7 @@ _io = [
         # Pin 5 - GND
         # Pin 6 - VCC
         Subsignal("tx", Pins(tofe_pin(tofe_low_speed_pmod_io('p3', 2)))),
-        Subsignal("rx", Pins(tofe_pin(tofe_low_speed_pmod_io('p3', 3)))),
+        Subsignal("rx", Pins(tofe_pin(tofe_low_speed_pmod_io('p3', 3))), Misc("PULLUP")),
         IOStandard("LVCMOS33")
     ),
 ]

--- a/opsis_platform.py
+++ b/opsis_platform.py
@@ -214,8 +214,16 @@ _io = [
 
     # serial
     ("serial", 0,
-        Subsignal("tx", Pins(tofe_pin(tofe_low_speed_pmod_io('p3', 1)))), # d9
-        Subsignal("rx", Pins(tofe_pin(tofe_low_speed_pmod_io('p3', 7)))), # d8
+        # PmodUSBUART
+        # Pmod Type4 - UART
+        # Pin 1 - CTS - In  - Peripheral can transmit
+        # Pin 2 - TXD - Out - Data - Host to peripheral
+        # Pin 3 - RXD - In  - Data - Peripheral to host
+        # Pin 4 - RTS - Out - Peripheral ready for data
+        # Pin 5 - GND
+        # Pin 6 - VCC
+        Subsignal("tx", Pins(tofe_pin(tofe_low_speed_pmod_io('p3', 2)))),
+        Subsignal("rx", Pins(tofe_pin(tofe_low_speed_pmod_io('p3', 3)))),
         IOStandard("LVCMOS33")
     ),
 ]

--- a/opsis_platform.py
+++ b/opsis_platform.py
@@ -4,53 +4,93 @@ from litex.build.xilinx import XilinxPlatform, iMPACT
 from tofe_lowspeedio import *
 
 _tofe_io = {
+    # A pairs - 2 x Diff CLK, 6 x Diff IO
+    # --------------------
+    # CLK A0 pair - L36
+    "diff_io_a0n" : "F15", # GCLK14
+    "diff_io_a0p" : "F14", # GCLK15
+    # CLK A1 Pair - L34
+    # - Connected with swapped N/P on Opsis (https://github.com/timvideos/HDMI2USB-numato-opsis-hardware/issues/56)
+    "diff_clk_a1n": "G9",
+    "diff_clk_a1p": "F10",
+    # IO A0 Pair
     "diff_io_a0n" : "C18",
     "diff_io_a0p" : "D17",
-    "diff_io_b0n" : "A20",
-    "diff_io_b0p" : "B20",
-    "diff_io_xn"  : "A19",
-    "diff_io_xp"  : "C19",
+    # IO A1 Pair
     "diff_io_a1n" : "A18",
     "diff_io_a1p" : "B18",
-    "diff_clk_xn" : "D19",
-    "diff_clk_xp" : "D18",
-    "diff_io_b1n" : "F17",
-    "diff_io_b1p" : "G16",
-    "diff_io_b2n" : "A17",
-    "diff_io_b2p" : "C17",
+    # IO A2 Pair
     "diff_io_a2n" : "G15",
     "diff_io_a2p" : "H14",
+    # IO A3 Pair
     "diff_io_a3n" : "G13",
     "diff_io_a3p" : "H13",
-    "diff_clk_b0p": "F16",
-    "diff_clk_b0n": "E16",
-    "diff_io_a0n" : "F15",
-    "diff_io_a0p" : "F14",
-    "diff_clk_b1n": "G11",
-    "diff_clk_b1p": "H12",
-    "diff_clk_a1n": "F10",
-    "diff_clk_a1p": "G9",
-    "diff_io_b3n" : "H11",
-    "diff_io_b3p" : "H10",
-    "diff_io_zn"  : "F9",
-    "diff_io_zp"  : "G8",
-    "diff_io_b5n" : "A5",
-    "diff_io_b5p" : "C5",
-    "diff_io_yn"  : "F8",
-    "diff_io_yp"  : "F7",
-    "diff_io_a5n" : "A4",
-    "diff_io_a5p" : "C4",
-    "diff_io_b6n" : "A3",
-    "diff_io_b6p" : "B3",
+    # IO A4 Pair
     "diff_io_a4n" : "E6",
     "diff_io_a4p" : "E5",
+    # IO A5 Pair
+    "diff_io_a5n" : "A4",
+    "diff_io_a5p" : "C4",
+    # IO A6 Pair
     "diff_io_a6n" : "A2",
     "diff_io_a6p" : "B2",
+
+    # B pairs - 2 x Diff CLK, 6 x Diff IO
+    # --------------------
+    # CLK B0 Pair
+    # - Connected with swapped N/P on Opsis (https://github.com/timvideos/HDMI2USB-numato-opsis-hardware/issues/58)
+    "diff_clk_b0p": "F16",
+    "diff_clk_b0n": "E16",
+    # CLK B1 Pair
+    "diff_clk_b1n": "G11",
+    "diff_clk_b1p": "H12",
+    # IO B0 Pair
+    "diff_io_b0n" : "A20",
+    "diff_io_b0p" : "B20",
+    # IO B1 Pair
+    "diff_io_b1n" : "F17",
+    "diff_io_b1p" : "G16",
+    # IO B2 Pair
+    "diff_io_b2n" : "A17",
+    "diff_io_b2p" : "C17",
+    # IO B3 Pair
+    "diff_io_b3n" : "H11",
+    "diff_io_b3p" : "H10",
+    # IO B4 Pair
     "diff_io_b4n" : "D5",
     "diff_io_b4p" : "D4",
+    # IO B5 Pair
+    "diff_io_b5n" : "A5",
+    "diff_io_b5p" : "C5",
+    # IO B6 Pair
+    "diff_io_b6n" : "A3",
+    "diff_io_b6p" : "B3",
+
+    # Special pairs
+    # --------------------
+    # CLK XN Pair
+    # - Not a clock pair on Opsis
+    "diff_clk_xn" : "D19",
+    "diff_clk_xp" : "D18",
+    # IO X Pair
+    "diff_io_xn"  : "A19",
+    "diff_io_xp"  : "C19",
+    # IO Y Pair
+    "diff_io_yn"  : "F8",
+    "diff_io_yp"  : "F7",
+    # IO Z Pair
+    "diff_io_zn"  : "F9",
+    "diff_io_zp"  : "G8",
+
+    # IO0
+    # - Isn't connected on Opsis board.
+    "io0"         : None,
+
+    # Control Signals
+    # --------------------
     "smclk"       : "N6",
     "smdat"       : "N7",
-    "pcie_reset"  : "D3"
+    "pcie_reset"  : "D3",
 }
 
 def tofe_pin(tofe_netname):

--- a/opsis_sim.py
+++ b/opsis_sim.py
@@ -2,6 +2,7 @@
 
 import argparse
 import importlib
+import os
 
 from litex.gen import *
 from litex.gen.genlib.io import CRG

--- a/opsis_sim.py
+++ b/opsis_sim.py
@@ -144,9 +144,11 @@ def main():
 
     cls = MiniSoC if args.with_ethernet else BaseSoC
     soc = cls(**soc_sdram_argdict(args))
-    builder = Builder(soc, output_dir="build",
+    builder = Builder(soc, output_dir="build/opsis_sim/",
                       compile_gateware=not args.nocompile_gateware,
-                      csr_csv="test/csr.csv")
+                      csr_csv="build/opsis_sim/test/csr.csv")
+    builder.add_software_package("libuip", "{}/firmware/libuip".format(os.getcwd()))
+    builder.add_software_package("firmware", "{}/firmware".format(os.getcwd()))
     builder.build()
 
 

--- a/opsis_sim.py
+++ b/opsis_sim.py
@@ -149,6 +149,7 @@ def main():
                       csr_csv="build/opsis_sim/test/csr.csv")
     builder.add_software_package("libuip", "{}/firmware/libuip".format(os.getcwd()))
     builder.add_software_package("firmware", "{}/firmware".format(os.getcwd()))
+    os.makedirs("build/opsis_sim/test") # FIXME: Remove when builder does this.
     builder.build()
 
 

--- a/opsis_video.py
+++ b/opsis_video.py
@@ -78,9 +78,11 @@ def main():
 
     platform = opsis_platform.Platform()
     soc = VideoMixerSoC(platform, **soc_sdram_argdict(args))
-    builder = Builder(soc, output_dir="build",
+    builder = Builder(soc, output_dir="build/opsis_video/",
                       compile_gateware=not args.nocompile_gateware,
-                      csr_csv="test/csr.csv")
+                      csr_csv="build/opsis_video/test/csr.csv")
+    builder.add_software_package("libuip", "{}/firmware/libuip".format(os.getcwd()))
+    builder.add_software_package("firmware", "{}/firmware".format(os.getcwd()))
     vns = builder.build()
 
 if __name__ == "__main__":

--- a/opsis_video.py
+++ b/opsis_video.py
@@ -83,6 +83,7 @@ def main():
                       csr_csv="build/opsis_video/test/csr.csv")
     builder.add_software_package("libuip", "{}/firmware/libuip".format(os.getcwd()))
     builder.add_software_package("firmware", "{}/firmware".format(os.getcwd()))
+    os.makedirs("build/opsis_video/test") # FIXME: Remove when builder does this.
     vns = builder.build()
 
 if __name__ == "__main__":

--- a/tofe_axiom.py
+++ b/tofe_axiom.py
@@ -1,0 +1,105 @@
+
+_tofe_axiom = {
+    # North Connector
+    "north": {
+        # I2C Eeprom
+        "sda": "diff_clk_b1p",
+        "scl": "diff_clk_b1n",
+
+        # IO pins
+        "io0": "diff_clk_xp",
+        "io1": "diff_io_b6n",
+        "io2": "diff_io_b6p",
+        "io3": "diff_io_zn",
+        "io4": "diff_io_yn",
+        "io5": "diff_io_xn",
+        "io6": "diff_io_b0n",
+        "io7": "diff_io_b0p",
+
+        # LVDS Pairs
+        "lvds_0p": "diff_io_b1p",
+        "lvds_0n": "diff_io_b1n",
+
+        "lvds_1p": "diff_io_b2p",
+        "lvds_1n": "diff_io_b2n",
+
+        "lvds_2p": "diff_io_b3p",
+        "lvds_2n": "diff_io_b3n",
+
+        "lvds_3p": "diff_clk_b0p",
+        "lvds_3n": "diff_clk_b0n",
+
+        "lvds_4p": "diff_io_b4p",
+        "lvds_4n": "diff_io_b4n",
+
+        "lvds_5p": "diff_io_b5p",
+        "lvds_5n": "diff_io_b5n",
+    }
+
+    # South Connector
+    "south": {
+        # I2C Eeprom
+        "sda": "diff_clk_a1p",
+        "scl": "diff_clk_a1n",
+
+        # IO pins
+        "io0": "diff_clk_xn",
+        "io1": "diff_io_a6n",
+        "io2": "diff_io_a6p",
+        "io3": "diff_io_zp",
+        "io4": "diff_io_yp",
+        "io5": "diff_io_xp",
+        "io6": "diff_io_a0n",
+        "io7": "diff_io_a0p",
+
+        # LVDS Pairs
+        "lvds_0p": "diff_io_a1p",
+        "lvds_0n": "diff_io_a1n",
+
+        "lvds_1p": "diff_io_a2p",
+        "lvds_1n": "diff_io_a2n",
+
+        "lvds_2p": "diff_io_a3p",
+        "lvds_2n": "diff_io_a3n",
+
+        "lvds_3p": "diff_clk_a0p",
+        "lvds_3n": "diff_clk_a0n",
+
+        "lvds_4p": "diff_io_a4p",
+        "lvds_4n": "diff_io_a4n",
+
+        "lvds_5p": "diff_io_a5p",
+        "lvds_5n": "diff_io_a5n",
+    }
+}
+
+_axiom_hdmi = {
+    # Control Signals
+    #"io0": None,
+    "io1": "eq0",
+    "io2": "ihp",
+    "io3": "ddet",
+    "io4": "eq1",
+    "io5": "ddc_en",
+    "io6": "oe",
+    "io7": "en",
+
+    # LVDS Pairs
+    "lvds_0p": "data2_p",
+    "lvds_0n": "data2_n",
+
+    "lvds_1p": "data1_p",
+    "lvds_1n": "data1_n",
+
+    "lvds_2p": "data0_p",
+    "lvds_2n": "data0_n",
+
+    "lvds_3p": "clk_p",
+    "lvds_3n": "clk_n",
+
+    #"lvds_4p": None,
+    #"lvds_4n": None,
+
+    "lvds_5p": "scl",
+    "lvds_5n": "sda",
+}

--- a/tofe_lowspeedio.py
+++ b/tofe_lowspeedio.py
@@ -63,6 +63,9 @@ _tofe_low_speed_pmod_io = {
    # Pin  1, Pin  2, Pin  3, Pin  4, Pin  5 (GND), Pin  6 (VCC) - Outside Row / Top
    # Pin  7, Pin  8, Pin  9, Pin 10, Pin 11 (GND), Pin 12 (VCC) - Inside Row / Bottom
 
+   # WARNING: On the older revisions of the board, the silk screen has labels
+   # for Pin 2/11 on the Pmod connectors which are *wrong*.
+
    # Dedicated Pmod connectors
   'p1': {
       1: "gpio0_p", 2: "gpio1_p", 3: "gpio2_p", 4: "gpio3_n",

--- a/tofe_lowspeedio.py
+++ b/tofe_lowspeedio.py
@@ -1,0 +1,88 @@
+
+_tofe_low_speed_io = {
+    # UART interface
+    "tx": "diff_io_xp",
+    "rx": "diff_io_xn",
+
+    # LEDs
+    "led1": "diff_io_a5p",
+    "led2": "diff_io_a5n",
+    "led3": "diff_io_b6n",
+    "led4": "diff_io_a6p",
+
+    # Push buttons
+    "sw1": "diff_clk_b0p",
+    "sw2": "diff_clk_b1n",
+    "sw3": "diff_clk_a1p",
+    "sw4": "diff_clk_a1n",
+
+    # PMOD - P1
+    "gpio0_n": "diff_io_a0n",
+    "gpio0_p": "diff_io_a0p",
+    "gpio1_n": "diff_io_b0n",
+    "gpio1_p": "diff_io_b0p",
+    "gpio2_n": "diff_clk_xn",
+    "gpio2_p": "diff_clk_xp",
+    "gpio3_n": "diff_io_a1n",
+    "gpio3_p": "diff_io_a1p",
+    # PMOD - P2
+    "gpio4_n": "diff_io_a2n",
+    "gpio4_p": "diff_io_a2p",
+    "gpio5_n": "diff_io_a3n",
+    "gpio5_p": "diff_io_a3p",
+    "gpio6_n": "diff_clk_a0n",
+    "gpio6_p": "diff_clk_a0p",
+    "gpio7_n": "diff_io_a4n",
+    "gpio7_p": "diff_io_a4p",
+
+    # Arduino Zero header (shared with PMOD - P3 & P4)
+    "d0" : "diff_io_yn",
+    "d1" : "diff_io_b1p",
+    "d2" : "diff_io_b1n",
+    "d3" : "diff_io_b2p",
+    "d4" : "diff_io_b2n",
+    "d5" : "diff_io_yp",
+    "d6" : "diff_io_b3n",
+    "d7" : "diff_io_b3p",
+    "d8" : "diff_clk_b0n",
+    "d9" : "diff_clk_b0p",
+    "d10": "diff_io_zn",
+    "d11": "diff_io_zp",
+    "d12": "diff_io_b4p",
+    "d13": "diff_io_b4n",
+    "d14": "diff_io_b5n",
+    "d15": "diff_io_b6p",
+}
+
+def tofe_low_speed_io(lowspeedio_netname):
+    """Return the TOFE signal name associated with LowSpeedIO net name."""
+    return _tofe_low_speed_io[lowspeedio_netname]
+
+_tofe_low_speed_pmod_io = {
+   # '<pmod name>': { <pin>: '<net name>', .... }
+   # Pin  1, Pin  2, Pin  3, Pin  4, Pin  5 (GND), Pin  6 (VCC) - Outside Row / Top
+   # Pin  7, Pin  8, Pin  9, Pin 10, Pin 11 (GND), Pin 12 (VCC) - Inside Row / Bottom
+
+   # Dedicated Pmod connectors
+  'p1': {
+      1: "gpio0_p", 2: "gpio1_p", 3: "gpio2_p", 4: "gpio3_n",
+      7: "gpio0_n", 8: "gpio1_n", 9: "gpio2_n", 10: "gpio3_p",
+  },
+  'p2': {
+      1: "gpio4_p", 2: "gpio4_n", 3: "gpio5_p", 4: "gpio5_n",
+      7: "gpio6_p", 8: "gpio6_n", 9: "gpio7_p", 10: "gpio7_n",
+  },
+  # Pmods shared with the Arduino Zero header
+  'p3': {
+      1: "d9", 2: "d11", 3: "d13", 4: "d15",
+      7: "d8", 8: "d10", 9: "d12", 10: "d14",
+  },
+  'p4': {
+      1: "d1", 2: "d3", 3: "d5", 4: "d7",
+      7: "d0", 8: "d2", 9: "d4", 10: "d6",
+  },
+}
+
+def tofe_low_speed_pmod_io(pmod_name, pin):
+    """Return the TOFE signal name associated with Pmod pin."""
+    return tofe_low_speed_io(_tofe_low_speed_pmod_io[pmod_name][pin])

--- a/tofe_lowspeedio.py
+++ b/tofe_lowspeedio.py
@@ -1,8 +1,8 @@
 
 _tofe_low_speed_io = {
     # UART interface
-    "tx": "diff_io_xp",
-    "rx": "diff_io_xn",
+    "tx": "diff_io_xp", # UART->Host
+    "rx": "diff_io_xn", # Host->UART
 
     # LEDs
     "led1": "diff_io_a5p",


### PR DESCRIPTION
Fixes issue #3.

Allows the usage of any of;
 * FX2 in USB UART mode (using [HDMI2USB-mode-switch tool](https://github.com/timvideos/HDMI2USB-mode-switch) using `opsis-mode-switch --mode serial`)
 * USB UART on TOFE LowSpeedIO board
 * A [Pmod USB UART](http://store.digilentinc.com/pmodusbuart-usb-to-uart-interface/) on the "top half" of the P3 connector on the TOFE LowSpeedIO board

I've tested by uploading the lm32 firmware using flterm (using `serialboot` mode) and using the console on the firmware in `firmware/`.

 * Merge https://github.com/enjoy-digital/opsis-soc/pull/20 first.