### PR TITLE
Fix printfs are all screwy for some builds

### DIFF
--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -20,7 +20,8 @@ OBJECTS=isr.o \
 		ci.o \
 		encoder.o \
 		i2c.o \
-		main.o
+		main.o \
+		stdio_wrap.o \
 
 CFLAGS += \
 	-I. \

--- a/firmware/ci.c
+++ b/firmware/ci.c
@@ -24,143 +24,106 @@
 #include "hdmi_out1.h"
 
 
-int ci_puts(const char *s)
-{
-#ifdef ETHMAC_BASE
-	if(telnet_active)
-		telnet_puts(s);
-	else
-#endif
-		puts(s);
-	return 0;
-}
-
-int ci_printf(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
-int ci_printf(const char *fmt, ...)
-{
-	int len;
-	va_list args;
-	va_start(args, fmt);
-#ifdef ETHMAC_BASE
-	if(telnet_active)
-		len = telnet_vprintf(fmt, args);
-	else
-#endif
-		len = vprintf(fmt, args);
-	va_end(args);
-	return len;
-}
-
-void ci_putsnonl(const char *s)
-{
-#ifdef ETHMAC_BASE
-	if(telnet_active)
-		telnet_putsnonl(s);
-	else
-#endif
-		putsnonl(s);
-}
-
 int status_enabled;
 
 static void help_video_matrix(void)
 {
-	ci_puts("video_matrix commands (alias: 'x')");
-	ci_puts("  video_matrix list              - list available video sinks and sources");
-	ci_puts("  x l                            - list available video sinks and sources");
-	ci_puts("  video_matrix connect <source>  - connect video source to video sink");
-	ci_puts("                       <sink>");
-	ci_puts("  x c <source> <sink>            - connect video source to video sink");
+	wputs("video_matrix commands (alias: 'x')");
+	wputs("  video_matrix list              - list available video sinks and sources");
+	wputs("  x l                            - list available video sinks and sources");
+	wputs("  video_matrix connect <source>  - connect video source to video sink");
+	wputs("                       <sink>");
+	wputs("  x c <source> <sink>            - connect video source to video sink");
 }
 
 static void help_video_mode(void)
 {
-	ci_puts("video_mode commands (alias: 'm')");
-	ci_puts("  video_mode list                - list available video modes");
-	ci_puts("  m l                            - list available video modes");
-	ci_puts("  video_mode <mode>              - select video mode");
+	wputs("video_mode commands (alias: 'm')");
+	wputs("  video_mode list                - list available video modes");
+	wputs("  m l                            - list available video modes");
+	wputs("  video_mode <mode>              - select video mode");
 }
 
 static void help_hdp_toggle(void)
 {
-	ci_puts("hdp_toggle <source>              - toggle HDP on source for EDID rescan");
+	wputs("hdp_toggle <source>              - toggle HDP on source for EDID rescan");
 }
 
 static void help_status(void)
 {
-	ci_puts("status commands (alias: 's')");
-	ci_puts("  status                         - print status message once");
-	ci_puts("  status <on/off>                - repeatedly print status message");
+	wputs("status commands (alias: 's')");
+	wputs("  status                         - print status message once");
+	wputs("  status <on/off>                - repeatedly print status message");
 }
 
 #ifdef CSR_HDMI_OUT0_BASE
 static void help_output0(void)
 {
-	ci_puts("output0 commands (alias: '0')");
-	ci_puts("  output0 on                     - enable output0");
-	ci_puts("  output0 off                    - disable output0");
+	wputs("output0 commands (alias: '0')");
+	wputs("  output0 on                     - enable output0");
+	wputs("  output0 off                    - disable output0");
 }
 #endif
 
 #ifdef CSR_HDMI_OUT1_BASE
 static void help_output1(void)
 {
-	ci_puts("output1 commands (alias: '1')");
-	ci_puts("  output1 on                     - enable output1");
-	ci_puts("  output1 off                    - disable output1");
+	wputs("output1 commands (alias: '1')");
+	wputs("  output1 on                     - enable output1");
+	wputs("  output1 off                    - disable output1");
 }
 #endif
 
 #ifdef ENCODER_BASE
 static void help_encoder(void)
 {
-	ci_puts("encoder commands (alias: 'e')");
-	ci_puts("  encoder on                     - enable encoder");
-	ci_puts("  encoder off                    - disable encoder");
-	ci_puts("  encoder quality <quality>      - select quality");
-	ci_puts("  encoder fps <fps>              - configure target fps");
+	wputs("encoder commands (alias: 'e')");
+	wputs("  encoder on                     - enable encoder");
+	wputs("  encoder off                    - disable encoder");
+	wputs("  encoder quality <quality>      - select quality");
+	wputs("  encoder fps <fps>              - configure target fps");
 }
 #endif
 
 static void help_debug(void)
 {
-    ci_puts("debug commands (alias 'd')");
-	ci_puts("  debug pll                      - dump pll configuration");
+    wputs("debug commands (alias 'd')");
+	wputs("  debug pll                      - dump pll configuration");
 #ifdef CSR_SDRAM_CONTROLLER_BANDWIDTH_UPDATE_ADDR
-	ci_puts("  debug ddr                      - show DDR bandwidth");
+	wputs("  debug ddr                      - show DDR bandwidth");
 #endif
-	ci_puts("  debug dna                      - show Board's DNA");
-	ci_puts("  debug edid                     - dump monitor EDID");
+	wputs("  debug dna                      - show Board's DNA");
+	wputs("  debug edid                     - dump monitor EDID");
 }
 
 static void ci_help(void)
 {
-	ci_puts("help        - this command");
-	ci_puts("reboot      - reboot CPU");
+	wputs("help        - this command");
+	wputs("reboot      - reboot CPU");
 #ifdef CSR_ETHPHY_MDIO_W_ADDR
-	ci_puts("mdio_dump   - dump mdio registers");
-	ci_puts("mdio_status - show mdio status");
+	wputs("mdio_dump   - dump mdio registers");
+	wputs("mdio_status - show mdio status");
 #endif
-	ci_puts("");
+	wputs("");
 	help_status();
-	ci_puts("");
+	wputs("");
 	help_video_matrix();
-	ci_puts("");
+	wputs("");
 	help_video_mode();
-	ci_puts("");
+	wputs("");
 	help_hdp_toggle();
-	ci_puts("");
+	wputs("");
 #ifdef CSR_HDMI_OUT0_BASE
 	help_output0();
-	ci_puts("");
+	wputs("");
 #endif
 #ifdef CSR_HDMI_OUT1_BASE
 	help_output1();
-	ci_puts("");
+	wputs("");
 #endif
 #ifdef ENCODER_BASE
 	help_encoder();
-	ci_puts("");
+	wputs("");
 #endif
 	help_debug();
 }
@@ -207,7 +170,7 @@ static char *readstr(void)
 				case 0x08:
 					if(ptr > 0) {
 						ptr--;
-						ci_putsnonl("\x08 \x08");
+						wputsnonl("\x08 \x08");
 					}
 					break;
 				case 0x07:
@@ -215,13 +178,13 @@ static char *readstr(void)
 				case '\r':
 				case '\n':
 					s[ptr] = 0x00;
-					ci_putsnonl("\n");
+					wputsnonl("\n");
 					ptr = 0;
 					return s;
 				default:
 					if(ptr >= (sizeof(s) - 1))
 						break;
-					ci_putsnonl(c);
+					wputsnonl(c);
 					s[ptr] = c[0];
 					ptr++;
 					break;
@@ -260,7 +223,7 @@ static void reboot(void)
 
 static void status_enable(void)
 {
-	ci_printf("Enabling status\r\n");
+	wprintf("Enabling status\r\n");
 	status_enabled = 1;
 #ifdef ENCODER_BASE
 	encoder_bandwidth_nbytes_clear_write(1);
@@ -269,7 +232,7 @@ static void status_enable(void)
 
 static void status_disable(void)
 {
-	ci_printf("Disabling status\r\n");
+	wprintf("Disabling status\r\n");
 	status_enabled = 0;
 }
 
@@ -278,53 +241,53 @@ static void debug_ddr(void);
 static void status_print(void)
 {
 #ifdef CSR_HDMI_IN0_BASE
-	ci_printf(
+	wprintf(
 		"input0:  %dx%d",
 		hdmi_in0_resdetection_hres_read(),
 		hdmi_in0_resdetection_vres_read());
-	ci_printf("\r\n");
+	wprintf("\r\n");
 #endif
 
 #ifdef CSR_HDMI_IN1_BASE
-	ci_printf(
+	wprintf(
 		"input1:  %dx%d",
 		hdmi_in1_resdetection_hres_read(),
 		hdmi_in1_resdetection_vres_read());
-	ci_printf("\r\n");
+	wprintf("\r\n");
 #endif
 
 #ifdef CSR_HDMI_OUT0_BASE
-	ci_printf("output0: ");
+	wprintf("output0: ");
 	if(hdmi_out0_core_initiator_enable_read())
-		ci_printf(
+		wprintf(
 			"%dx%d@%dHz from %s",
 			processor_h_active,
 			processor_v_active,
 			processor_refresh,
 			processor_get_source_name(processor_hdmi_out0_source));
 	else
-		ci_printf("off");
-	ci_printf("\r\n");
+		wprintf("off");
+	wprintf("\r\n");
 #endif
 
 #ifdef CSR_HDMI_OUT1_BASE
-	ci_printf("output1: ");
+	wprintf("output1: ");
 	if(hdmi_out1_core_initiator_enable_read())
-		ci_printf(
+		wprintf(
 			"%dx%d@%uHz from %s",
 			processor_h_active,
 			processor_v_active,
 			processor_refresh,
 			processor_get_source_name(processor_hdmi_out1_source));
 	else
-		ci_printf("off");
-	ci_printf("\r\n");
+		wprintf("off");
+	wprintf("\r\n");
 #endif
 
 #ifdef ENCODER_BASE
-	ci_printf("encoder: ");
+	wprintf("encoder: ");
 	if(encoder_enabled) {
-		ci_printf(
+		wprintf(
 			"%dx%d @ %dfps (%dMbps) from %s (q: %d)",
 			processor_h_active,
 			processor_v_active,
@@ -334,11 +297,11 @@ static void status_print(void)
 			encoder_quality);
 		encoder_bandwidth_nbytes_clear_write(1);
 	} else
-		ci_printf("off");
-	ci_printf("\r\n");
+		wprintf("off");
+	wprintf("\r\n");
 #endif
 #ifdef CSR_SDRAM_CONTROLLER_BANDWIDTH_UPDATE_ADDR
-	ci_printf("ddr: ");
+	wprintf("ddr: ");
 	debug_ddr();
 #endif
 }
@@ -350,7 +313,7 @@ static void status_service(void)
 	if(elapsed(&last_event, SYSTEM_CLOCK_FREQUENCY)) {
 		if(status_enabled) {
 			status_print();
-			ci_printf("\r\n");
+			wprintf("\r\n");
 		}
 	}
 }
@@ -369,32 +332,32 @@ static void status_service(void)
 
 static void video_matrix_list(void)
 {
-	ci_printf("Video sources:\r\n");
+	wprintf("Video sources:\r\n");
 #ifdef CSR_HDMI_IN0_BASE
-	ci_printf("input0 (0): %s\r\n", HDMI_IN0_MNEMONIC);
-	ci_puts(HDMI_IN0_DESCRIPTION);
+	wprintf("input0 (0): %s\r\n", HDMI_IN0_MNEMONIC);
+	wputs(HDMI_IN0_DESCRIPTION);
 #endif
 #ifdef CSR_HDMI_IN1_BASE
-	ci_printf("input1 (1): %s\r\n", HDMI_IN1_MNEMONIC);
-	ci_puts(HDMI_IN1_DESCRIPTION);
+	wprintf("input1 (1): %s\r\n", HDMI_IN1_MNEMONIC);
+	wputs(HDMI_IN1_DESCRIPTION);
 #endif
-	ci_printf("pattern (p):\r\n");
-	ci_printf("  Video pattern\r\n");
-	ci_puts(" ");
-	ci_printf("Video sinks:\r\n");
+	wprintf("pattern (p):\r\n");
+	wprintf("  Video pattern\r\n");
+	wputs(" ");
+	wprintf("Video sinks:\r\n");
 #ifdef CSR_HDMI_OUT0_BASE
-	ci_printf("output0 (0): %s\r\n", HDMI_OUT0_MNEMONIC);
-	ci_puts(HDMI_OUT0_DESCRIPTION);
+	wprintf("output0 (0): %s\r\n", HDMI_OUT0_MNEMONIC);
+	wputs(HDMI_OUT0_DESCRIPTION);
 #endif
 #ifdef CSR_HDMI_OUT1_BASE
-	ci_printf("output1 (1): %s\r\n", HDMI_OUT1_MNEMONIC);
-	ci_puts(HDMI_OUT1_DESCRIPTION);
+	wprintf("output1 (1): %s\r\n", HDMI_OUT1_MNEMONIC);
+	wputs(HDMI_OUT1_DESCRIPTION);
 #endif
 #ifdef ENCODER_BASE
-	ci_printf("encoder (e):\r\n");
-	ci_printf("  JPEG encoder (USB output)\r\n");
+	wprintf("encoder (e):\r\n");
+	wprintf("  JPEG encoder (USB output)\r\n");
 #endif
-	ci_puts(" ");
+	wputs(" ");
 }
 
 static void video_matrix_connect(int source, int sink)
@@ -402,24 +365,24 @@ static void video_matrix_connect(int source, int sink)
 	if(source >= 0 && source <= VIDEO_IN_PATTERN)
 	{
 		if(sink >= 0 && sink <= VIDEO_OUT_HDMI_OUT1) {
-			ci_printf("Connecting %s to output%d\r\n", processor_get_source_name(source), sink);
+			wprintf("Connecting %s to output%d\r\n", processor_get_source_name(source), sink);
 			if(sink == VIDEO_OUT_HDMI_OUT0)
 #ifdef CSR_HDMI_OUT0_BASE
 				processor_set_hdmi_out0_source(source);
 #else
-				ci_printf("hdmi_out0 is missing.\r\n");
+				wprintf("hdmi_out0 is missing.\r\n");
 #endif
 			else if(sink == VIDEO_OUT_HDMI_OUT1)
 #ifdef CSR_HDMI_OUT1_BASE
 				processor_set_hdmi_out1_source(source);
 #else
-				ci_printf("hdmi_out1 is missing.\r\n");
+				wprintf("hdmi_out1 is missing.\r\n");
 #endif
 			processor_update();
 		}
 #ifdef ENCODER_BASE
 		else if(sink == VIDEO_OUT_ENCODER) {
-			ci_printf("Connecting %s to encoder\r\n", processor_get_source_name(source));
+			wprintf("Connecting %s to encoder\r\n", processor_get_source_name(source));
 			processor_set_encoder_source(source);
 			processor_update();
 		}
@@ -433,10 +396,10 @@ static void video_mode_list(void)
 	int i;
 
 	processor_list_modes(mode_descriptors);
-	ci_printf("Available video modes:\r\n");
+	wprintf("Available video modes:\r\n");
 	for(i=0;i<PROCESSOR_MODE_COUNT;i++)
-		ci_printf("mode %d: %s\r\n", i, &mode_descriptors[i*PROCESSOR_MODE_DESCLEN]);
-	ci_printf("\r\n");
+		wprintf("mode %d: %s\r\n", i, &mode_descriptors[i*PROCESSOR_MODE_DESCLEN]);
+	wprintf("\r\n");
 }
 
 static void video_mode_set(int mode)
@@ -444,7 +407,7 @@ static void video_mode_set(int mode)
 	char mode_descriptors[PROCESSOR_MODE_COUNT*PROCESSOR_MODE_DESCLEN];
 	if(mode < PROCESSOR_MODE_COUNT) {
 		processor_list_modes(mode_descriptors);
-		ci_printf("Setting video mode to %s\r\n", &mode_descriptors[mode*PROCESSOR_MODE_DESCLEN]);
+		wprintf("Setting video mode to %s\r\n", &mode_descriptors[mode*PROCESSOR_MODE_DESCLEN]);
 		config_set(CONFIG_KEY_RESOLUTION, mode);
 		processor_start(mode);
 	}
@@ -455,7 +418,7 @@ static void hdp_toggle(int source)
 #if defined(CSR_HDMI_IN0_BASE) || defined(CSR_HDMI_IN1_BASE)
 	int i;
 #endif
-	ci_printf("Toggling HDP on output%d\r\n", source);
+	wprintf("Toggling HDP on output%d\r\n", source);
 #ifdef CSR_HDMI_IN0_BASE
 	if(source ==  VIDEO_IN_HDMI_IN0) {
 		hdmi_in0_edid_hpd_en_write(0);
@@ -463,7 +426,7 @@ static void hdp_toggle(int source)
 		hdmi_in0_edid_hpd_en_write(1);
 	}
 #else
-	ci_printf("hdmi_in0 is missing.\r\n");
+	wprintf("hdmi_in0 is missing.\r\n");
 #endif
 #ifdef CSR_HDMI_IN1_BASE
 	if(source == VIDEO_IN_HDMI_IN1) {
@@ -472,20 +435,20 @@ static void hdp_toggle(int source)
 		hdmi_in1_edid_hpd_en_write(1);
 	}
 #else
-	ci_printf("hdmi_in1 is missing.\r\n");
+	wprintf("hdmi_in1 is missing.\r\n");
 #endif
 }
 
 #ifdef CSR_HDMI_OUT0_BASE
 static void output0_on(void)
 {
-	ci_printf("Enabling output0\r\n");
+	wprintf("Enabling output0\r\n");
 	hdmi_out0_core_initiator_enable_write(1);
 }
 
 static void output0_off(void)
 {
-	ci_printf("Disabling output0\r\n");
+	wprintf("Disabling output0\r\n");
 	hdmi_out0_core_initiator_enable_write(0);
 }
 #endif
@@ -493,13 +456,13 @@ static void output0_off(void)
 #ifdef CSR_HDMI_OUT1_BASE
 static void output1_on(void)
 {
-	ci_printf("Enabling output1\r\n");
+	wprintf("Enabling output1\r\n");
 	hdmi_out1_core_initiator_enable_write(1);
 }
 
 static void output1_off(void)
 {
-	ci_printf("Disabling output1\r\n");
+	wprintf("Disabling output1\r\n");
 	hdmi_out1_core_initiator_enable_write(0);
 }
 #endif
@@ -507,25 +470,25 @@ static void output1_off(void)
 #ifdef ENCODER_BASE
 static void encoder_on(void)
 {
-	ci_printf("Enabling encoder\r\n");
+	wprintf("Enabling encoder\r\n");
 	encoder_enable(1);
 }
 
 static void encoder_configure_quality(int quality)
 {
-	ci_printf("Setting encoder quality to %d\r\n", quality);
+	wprintf("Setting encoder quality to %d\r\n", quality);
 	encoder_set_quality(quality);
 }
 
 static void encoder_configure_fps(int fps)
 {
-	ci_printf("Setting encoder fps to %d\r\n", fps);
+	wprintf("Setting encoder fps to %d\r\n", fps);
 	encoder_set_fps(fps);
 }
 
 static void encoder_off(void)
 {
-	ci_printf("Disabling encoder\r\n");
+	wprintf("Disabling encoder\r\n");
 	encoder_enable(0);
 }
 #endif
@@ -557,25 +520,25 @@ static void debug_ddr(void)
 	burstbits = (2*DFII_NPHASES) << DFII_PIX_DATA_SIZE;
 	rdb = (nr*f >> (24 - log2(burstbits)))/1000000ULL;
 	wrb = (nw*f >> (24 - log2(burstbits)))/1000000ULL;
-	ci_printf("read:%5dMbps  write:%5dMbps  all:%5dMbps\r\n", rdb, wrb, rdb + wrb);
+	wprintf("read:%5dMbps  write:%5dMbps  all:%5dMbps\r\n", rdb, wrb, rdb + wrb);
 }
 #endif
 
 #ifdef CSR_DNA_ID_ADDR
 void print_board_dna(void) {
 	int i;
-	ci_printf("Board's DNA: ");
+	wprintf("Board's DNA: ");
 	for(i=0; i<CSR_DNA_ID_SIZE; i++) {
-		ci_printf("%02x", MMPTR(CSR_DNA_ID_ADDR+4*i));
+		wprintf("%02x", MMPTR(CSR_DNA_ID_ADDR+4*i));
 	}
-	ci_printf("\n");
+	wprintf("\n");
 }
 
 #endif
 
 void ci_prompt(void)
 {
-	ci_printf("RUNTIME>");
+	wprintf("RUNTIME>");
 }
 
 void ci_service(void)
@@ -591,7 +554,7 @@ void ci_service(void)
 	token = get_token(&str);
 
     if(strcmp(token, "help") == 0) {
-		ci_puts("Available commands:");
+		wputs("Available commands:");
 		token = get_token(&str);
 		if(strcmp(token, "video_matrix") == 0)
 			help_video_matrix();
@@ -615,7 +578,7 @@ void ci_service(void)
 			help_debug();
 		else
 			ci_help();
-		ci_puts("");
+		wputs("");
 	}
 	else if(strcmp(token, "reboot") == 0) reboot();
 #ifdef CSR_ETHPHY_MDIO_W_ADDR
@@ -645,7 +608,7 @@ void ci_service(void)
 				source = VIDEO_IN_PATTERN;
 			}
 			else {
-				ci_printf("Unknown video source: '%s'\r\n", token);
+				wprintf("Unknown video source: '%s'\r\n", token);
 			}
 
 			/* get video sink */
@@ -661,7 +624,7 @@ void ci_service(void)
 				sink = VIDEO_OUT_ENCODER;
 			}
 			else
-				ci_printf("Unknown video sink: '%s'\r\n", token);
+				wprintf("Unknown video sink: '%s'\r\n", token);
 
 			if (source >= 0 && sink >= 0)
 				video_matrix_connect(source, sink);
@@ -735,13 +698,13 @@ void ci_service(void)
 #ifdef CSR_HDMI_IN0_BASE
 		else if(strcmp(token, "input0") == 0) {
 			hdmi_in0_debug = !hdmi_in0_debug;
-			ci_printf("HDMI Input 0 debug %s\r\n", hdmi_in0_debug ? "on" : "off");
+			wprintf("HDMI Input 0 debug %s\r\n", hdmi_in0_debug ? "on" : "off");
 		}
 #endif
 #ifdef CSR_HDMI_IN1_BASE
 		else if(strcmp(token, "input1") == 0) {
 			hdmi_in1_debug = !hdmi_in1_debug;
-			ci_printf("HDMI Input 1 debug %s\r\n", hdmi_in1_debug ? "on" : "off");
+			wprintf("HDMI Input 1 debug %s\r\n", hdmi_in1_debug ? "on" : "off");
 		}
 #endif
 #ifdef CSR_SDRAM_CONTROLLER_BANDWIDTH_UPDATE_ADDR
@@ -794,7 +757,7 @@ void ci_service(void)
 			}
 #endif
 			if(found == 0)
-				ci_printf("%s port has no EDID capabilities\r\n", token);
+				wprintf("%s port has no EDID capabilities\r\n", token);
 		} else
 			help_debug();
 	} else {

--- a/firmware/ci.c
+++ b/firmware/ci.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <stdarg.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -34,14 +35,20 @@ int ci_puts(const char *s)
 	return 0;
 }
 
+int ci_printf(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
 int ci_printf(const char *fmt, ...)
 {
+	int len;
+	va_list args;
+	va_start(args, fmt);
 #ifdef ETHMAC_BASE
 	if(telnet_active)
-		return telnet_printf(fmt);
+		len = telnet_vprintf(fmt, args);
 	else
 #endif
-		return printf(fmt);
+		len = vprintf(fmt, args);
+	va_end(args);
+	return len;
 }
 
 void ci_putsnonl(const char *s)

--- a/firmware/ci.h
+++ b/firmware/ci.h
@@ -1,9 +1,6 @@
 #ifndef __CI_H
 #define __CI_H
 
-int ci_puts(const char *s);
-int ci_printf(const char *fmt, ...);
-void ci_putsnonl(const char *s);
 void ci_prompt(void);
 void ci_service(void);
 

--- a/firmware/mdio.c
+++ b/firmware/mdio.c
@@ -88,38 +88,38 @@ int mdio_read(int phyadr, int reg)
 void mdio_dump(void) {
 	int i;
 	for(i=0; i<32; i++)
-		ci_printf("reg %d: %04x\n", i, mdio_read(0, i));
+		wprintf("reg %d: %04x\n", i, mdio_read(0, i));
 }
 
 int mdio_status(void) {
 	int status;
 	status = mdio_read(0, 17);
 
-	ci_printf("MDIO ");
+	wprintf("MDIO ");
 
-	ci_printf("mode: ");
+	wprintf("mode: ");
 	switch((status >> 14) & 0x3)
 	{
 		case 0b10:
-			ci_printf("1000Mbps");
+			wprintf("1000Mbps");
 			break;
 		case 0b01:
-			ci_printf("100Mbps");
+			wprintf("100Mbps");
 			break;
 		case 0b00:
-			ci_printf("10Mbps");
+			wprintf("10Mbps");
 			break;
 		default:
-			ci_printf("Reserved");
+			wprintf("Reserved");
 			break;
 	}
-	ci_printf(" / ");
-	ci_printf("link: ");
+	wprintf(" / ");
+	wprintf("link: ");
 	if((status >> 10) & 0x1)
-		ci_printf("up");
+		wprintf("up");
 	else
-		ci_printf("down");
-	ci_printf("\n");
+		wprintf("down");
+	wprintf("\n");
 	return 0;
 }
 

--- a/firmware/stdio_wrap.c
+++ b/firmware/stdio_wrap.c
@@ -1,0 +1,44 @@
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "telnet.h"
+
+#include "stdio_wrap.h"
+
+int wputs(const char *s)
+{
+#ifdef ETHMAC_BASE
+	if(telnet_active)
+		telnet_puts(s);
+	else
+#endif
+		puts(s);
+	return 0;
+}
+
+int wprintf(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
+int wprintf(const char *fmt, ...)
+{
+	int len;
+	va_list args;
+	va_start(args, fmt);
+#ifdef ETHMAC_BASE
+	if(telnet_active)
+		len = telnet_vprintf(fmt, args);
+	else
+#endif
+		len = vprintf(fmt, args);
+	va_end(args);
+	return len;
+}
+
+void wputsnonl(const char *s)
+{
+#ifdef ETHMAC_BASE
+	if(telnet_active)
+		telnet_putsnonl(s);
+	else
+#endif
+		putsnonl(s);
+}

--- a/firmware/stdio_wrap.h
+++ b/firmware/stdio_wrap.h
@@ -1,0 +1,5 @@
+#include <stdarg.h>
+
+int wputs(const char *s);
+int wprintf(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
+void wputsnonl(const char *s);

--- a/firmware/telnet.c
+++ b/firmware/telnet.c
@@ -1,6 +1,7 @@
 // This file is Copyright (c) 2015 Florent Kermarrec <florent@enjoy-digital.fr>
 // License: BSD
 
+#include <stdio.h>
 #include <stdarg.h>
 
 #include "telnet.h"
@@ -104,12 +105,17 @@ void telnet_putsnonl(const char *s)
 int telnet_printf(const char *fmt, ...)
 {
 	va_list args;
+	va_start(args, fmt);
+	telnet_vprintf(fmt, args);
+	va_end(args);
+}
+
+int telnet_vprintf(const char *fmt, va_list args)
+{
 	int len;
 	char outbuf[TELNET_PRINTF_BUFFER_SIZE];
 
-	va_start(args, fmt);
 	len = vscnprintf(outbuf, sizeof(outbuf), fmt, args);
-	va_end(args);
 	outbuf[len] = 0;
 	telnet_putsnonl(outbuf);
 

--- a/firmware/telnet.h
+++ b/firmware/telnet.h
@@ -4,6 +4,8 @@
 #ifndef __TELNET_H
 #define __TELNET_H
 
+#include <stdarg.h>
+
 #include "contiki.h"
 #include "contiki-net.h"
 
@@ -35,6 +37,8 @@ int telnet_readchar_nonblock(void);
 int telnet_putchar(char c);
 int telnet_puts(const char *s);
 void telnet_putsnonl(const char *s);
-int telnet_printf(const char *fmt, ...);
+
+int telnet_vprintf(const char *fmt, va_list argp);
+int telnet_printf(const char *fmt, ...) __attribute__((format(printf, 1, 2)));
 
 #endif


### PR DESCRIPTION
The problem causing this `ci_printf` function at https://github.com/enjoy-digital/opsis-soc/blob/master/firmware/ci.c#L37

You can't pass variable args forward like this. The compiler sees that the variable args are not used and thus optimises them out.

Fixes #28 .